### PR TITLE
Ensure 00_aria.cnf changes are applied

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,4 +4,8 @@ FROM --platform=${TARGETPLATFORM:-linux/amd64} yobasystems/alpine-mariadb
 
 LABEL maintainer="Jamie Curnow <jc@jc21.com>"
 
-ADD 00_aria.cnf /etc/mysql/conf.d/00_aria.cnf
+# mariadb does not appear to load conf.d files by default
+#ADD 00_aria.cnf /etc/mysql/conf.d/00_aria.cnf
+
+COPY 00_aria.cnf .
+RUN cat /00_aria.cnf >> /etc/mysql/my.cnf


### PR DESCRIPTION
MariaDB does not appear to automatically add files in conf.d so this change appends the 00_aria.cnf changes to the my.cnf file instead which does ensure aria is the selected DB which on ZFS is critical it turns out.